### PR TITLE
fixed close webpage prompt

### DIFF
--- a/AutoDownloadYouTubeVideo.ahk
+++ b/AutoDownloadYouTubeVideo.ahk
@@ -3,6 +3,7 @@
 SendMode "Input"
 SetWorkingDir A_ScriptDir
 CoordMode "Mouse", "Client"
+#MaxThreadsPerHotkey 1
 #Warn Unreachable, Off
 
 ; Imports important functions and variables

--- a/includes/DownloadManager.ahk
+++ b/includes/DownloadManager.ahk
@@ -79,7 +79,7 @@ startDownload(pURL)
                             Sleep(3000)
                             result := MsgBox("Would you like to close the browser instance now?", "Download completed !", "36 T5")
 
-                            If (result = "Yes" || "Timeout")
+                            If (result = "Yes" || result = "Timeout")
                             {
                                 WinClose(firefoxWindow)
                                 manageURLFile()


### PR DESCRIPTION
Fixed a bug where clicking "No" on the close download page prompt would still close it no matter what option the user selects. Added #MaxThreadsPerHotkey to prevent multiple background task from keeping the script running even though it should be terminated. Might not fix the termination issue!